### PR TITLE
[IMP] Allow to use HTTPS authentication

### DIFF
--- a/wocg/create_components.py
+++ b/wocg/create_components.py
@@ -19,7 +19,7 @@ from .tools.helper import get_component_name, get_component_slug
 from .tools.logger import get_logger
 
 
-GIT_URL_RE = re.compile(r"git@.*:.*/.*")
+GIT_URL_RE = re.compile(r"(git@.*:.*/.*)|(https://.*)")
 
 FILEMASK_RE = re.compile(
     r"^(?P<addons_dir>.*/)?(?P<addon_name>.*?)/i18n/\*\.po$")

--- a/wocg/create_project.py
+++ b/wocg/create_project.py
@@ -72,6 +72,7 @@ def create_project(
                 new_project, repository, branch, addon_name,
                 tmpl_component_slug,
                 addons_subdirectory=addons_subdirectory,
+                use_ssh=use_ssh,
             )
         except Exception as e:
             logger.exception(e)
@@ -104,7 +105,7 @@ def get_new_project(project_name, repository, tmpl_component_slug):
 
 def get_new_component(
         project, repository, branch, addon_name, tmpl_component_slug,
-        addons_subdirectory=None):
+        addons_subdirectory=None, use_ssh=False):
     po_file_mask = '{}/i18n/*.po'.format(addon_name)
     pot_filepath = '{addon_name}/i18n/{addon_name}.pot'.format(
         addon_name=addon_name)
@@ -115,13 +116,15 @@ def get_new_component(
     tmpl_component_pk = tmpl_component.pk
     parsed_repository_uri = giturlparse.parse(repository)
 
+    repo_url = use_ssh and parsed_repository_uri.url2ssh or repository
+
     new_component = tmpl_component
     new_component.pk = None
     new_component.project = project
     new_component.name = get_component_name(project, addon_name)
     new_component.slug = get_component_slug(project, addon_name)
-    new_component.repo = parsed_repository_uri.url2ssh
-    new_component.push = parsed_repository_uri.url2ssh
+    new_component.repo = repo_url
+    new_component.push = repo_url
     new_component.branch = branch
     new_component.filemask = po_file_mask
     new_component.new_base = pot_filepath

--- a/wocg/create_project.py
+++ b/wocg/create_project.py
@@ -8,6 +8,11 @@ import re
 import click
 import giturlparse
 
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
 import django
 django.setup()  # noqa: E402
 
@@ -84,7 +89,12 @@ def get_new_project(project_name, repository, tmpl_component_slug):
     new_project = Project()
     new_project.name = project_name
     new_project.slug = get_project_slug(project_name)
-    new_project.web = giturlparse.parse(repository).url2https
+    # strip user/password from https url
+    parsed_url = urlparse(giturlparse.parse(repository).url2https)
+    new_project.web = '%s://%s%s' % (
+        parsed_url.scheme,
+        parsed_url.hostname,
+        parsed_url.path)
     new_project.access_control = \
         tmpl_component.project.access_control
     new_project.enable_review = \


### PR DESCRIPTION
Without this PR it's not possible to use HTTPS authentication on repositories.

Now, if `use_ssh` is not explicitly enabled, the repository url will default to `https` style, making it compatible with https authentication.